### PR TITLE
Refactor calculator evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://bretwalda98.github.io/scicalx/
 * **Constants**: π (pi), e (Euler’s number)
 * **Parentheses**: Nested expressions
 * **ANS recall**: Reuse last result
+* **Secure evaluation**: Expressions are parsed by a small built-in parser instead of using dynamic code execution
 * **Responsive UI**: Grid layout, color‑coded keys, styled display
 
 ---

--- a/casio_calculator.html
+++ b/casio_calculator.html
@@ -126,6 +126,7 @@
     </div>
   </div>
 
+  <script src="evaluate.js"></script>
   <script>
     (() => {
       const display = document.getElementById('display');
@@ -134,23 +135,6 @@
       let expression = '';
       let lastAnswer = '0';
       let isDegree = false; // false => radian; true => degree
-
-      // Helper math functions with degree support
-      const trig = fn => x => (isDegree ? fn(x * Math.PI / 180) : fn(x));
-      const sin = trig(Math.sin);
-      const cos = trig(Math.cos);
-      const tan = trig(Math.tan);
-      const asin = trig(Math.asin);
-      const acos = trig(Math.acos);
-      const atan = trig(Math.atan);
-
-      const factorial = n => {
-        if (n < 0) return NaN;
-        if (n === 0 || n === 1) return 1;
-        let res = 1;
-        for (let i = 2; i <= n; i++) res *= i;
-        return res;
-      };
 
       const updateDisplay = () => {
         display.textContent = expression || '0';
@@ -178,32 +162,7 @@
 
       const compute = () => {
         try {
-          let expr = expression;
-          // Substitute constants
-          expr = expr.replace(/π/g, 'Math.PI');
-          expr = expr.replace(/e/g, 'Math.E');
-
-          // Substitute factorial (number!)
-          expr = expr.replace(/(\d+(?:\.\d+)?)!/g, 'factorial($1)');
-
-          // Substitute powers (x^y)
-          expr = expr.replace(/(\d+(?:\.\d+)?|[A-Za-z]+)\^(\d+(?:\.\d+)?)/g, 'Math.pow($1,$2)');
-
-          // Replace operators symbols
-          expr = expr.replace(/÷/g, '/').replace(/×/g, '*').replace(/−/g, '-');
-          expr = expr.replace(/%/g, '/100');
-
-          // Functions mapping
-          expr = expr.replace(/sin\(/g, 'sin(');
-          expr = expr.replace(/cos\(/g, 'cos(');
-          expr = expr.replace(/tan\(/g, 'tan(');
-          expr = expr.replace(/ln\(/g, 'Math.log(');
-          expr = expr.replace(/log\(/g, 'Math.log10(');
-          expr = expr.replace(/√\(/g, 'Math.sqrt(');
-
-          // Evaluate safely
-          const result = Function('sin,cos,tan,asin,acos,atan,factorial,Math','"use strict";return (' + expr + ')')(sin,cos,tan,asin,acos,atan,factorial,Math);
-
+          const result = evaluateExpression(expression, { isDegree });
           lastAnswer = String(result);
           expression = lastAnswer;
           updateDisplay();
@@ -218,7 +177,6 @@
         append(lastAnswer);
       };
 
-      // Attach listeners
       buttons.forEach(btn => {
         const val = btn.dataset.value;
         const action = btn.dataset.action;

--- a/evaluate.js
+++ b/evaluate.js
@@ -1,0 +1,121 @@
+(function (global) {
+  function factorial(n) {
+    if (n < 0) return NaN;
+    let res = 1;
+    for (let i = 2; i <= n; i++) res *= i;
+    return res;
+  }
+
+  function sanitize(expr) {
+    expr = expr.replace(/\s+/g, '');
+    const map = { '÷': '/', '×': '*', '−': '-', 'π': 'pi', '√': 'sqrt' };
+    expr = expr.replace(/[÷×−π√]/g, m => map[m] || m);
+    if (/[^0-9a-zA-Z+\-*/^%!().]/.test(expr)) throw new Error('Invalid characters');
+    return expr;
+  }
+
+  function tokenize(expr) {
+    const regex = /(pi|e|sqrt|sin|cos|tan|ln|log|\d*\.\d+|\d+|[()+\-*/^%!])/g;
+    const tokens = expr.match(regex);
+    if (!tokens || tokens.join('') !== expr) throw new Error('Invalid expression');
+    return tokens;
+  }
+
+  const precedence = {
+    'u-': 4,
+    '^': 3,
+    '*': 2,
+    '/': 2,
+    '+': 1,
+    '-': 1,
+    '!': 5,
+    '%': 5
+  };
+  const right = { '^': true, 'u-': true };
+
+  function toRPN(tokens) {
+    const output = [];
+    const stack = [];
+    let prev = null;
+    for (let token of tokens) {
+      if (/^\d/.test(token) || token === 'pi' || token === 'e') {
+        output.push(token);
+      } else if (/^(sin|cos|tan|ln|log|sqrt)$/.test(token)) {
+        stack.push(token);
+      } else if (token === '(') {
+        stack.push(token);
+      } else if (token === ')') {
+        while (stack.length && stack[stack.length - 1] !== '(') output.push(stack.pop());
+        if (stack[stack.length - 1] === '(') stack.pop();
+        if (stack.length && /^(sin|cos|tan|ln|log|sqrt)$/.test(stack[stack.length - 1])) output.push(stack.pop());
+      } else if (/^[+\-*/^%!]$/.test(token)) {
+        if (token === '-' && (prev === null || /^[+\-*/^!(]$/.test(prev))) token = 'u-';
+        while (stack.length && /^[+\-*/^%!u-]$/.test(stack[stack.length - 1]) &&
+          (precedence[stack[stack.length - 1]] > precedence[token] ||
+           (precedence[stack[stack.length - 1]] === precedence[token] && !right[token]))) {
+          output.push(stack.pop());
+        }
+        stack.push(token);
+      }
+      prev = token;
+    }
+    while (stack.length) output.push(stack.pop());
+    return output;
+  }
+
+  function evaluateRPN(rpn, isDegree) {
+    const stack = [];
+    const trig = fn => x => isDegree ? fn(x * Math.PI / 180) : fn(x);
+    for (let token of rpn) {
+      if (/^\d/.test(token)) {
+        stack.push(parseFloat(token));
+      } else if (token === 'pi') {
+        stack.push(Math.PI);
+      } else if (token === 'e') {
+        stack.push(Math.E);
+      } else if (token === 'u-') {
+        stack.push(-stack.pop());
+      } else if (token === '!') {
+        stack.push(factorial(stack.pop()));
+      } else if (token === '%') {
+        stack.push(stack.pop() / 100);
+      } else if (/^[+\-*/^]$/.test(token)) {
+        const b = stack.pop();
+        const a = stack.pop();
+        switch (token) {
+          case '+': stack.push(a + b); break;
+          case '-': stack.push(a - b); break;
+          case '*': stack.push(a * b); break;
+          case '/': stack.push(a / b); break;
+          case '^': stack.push(Math.pow(a, b)); break;
+        }
+      } else if (/^(sin|cos|tan|ln|log|sqrt)$/.test(token)) {
+        const a = stack.pop();
+        switch (token) {
+          case 'sin': stack.push(trig(Math.sin)(a)); break;
+          case 'cos': stack.push(trig(Math.cos)(a)); break;
+          case 'tan': stack.push(trig(Math.tan)(a)); break;
+          case 'ln': stack.push(Math.log(a)); break;
+          case 'log': stack.push(Math.log10(a)); break;
+          case 'sqrt': stack.push(Math.sqrt(a)); break;
+        }
+      }
+    }
+    if (stack.length !== 1) throw new Error('Invalid expression');
+    return stack[0];
+  }
+
+  function evaluateExpression(expr, options = {}) {
+    const isDegree = !!options.isDegree;
+    const sanitized = sanitize(expr);
+    const tokens = tokenize(sanitized);
+    const rpn = toRPN(tokens);
+    return evaluateRPN(rpn, isDegree);
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { evaluateExpression };
+  } else {
+    global.evaluateExpression = evaluateExpression;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/test/evaluate.test.js
+++ b/test/evaluate.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { evaluateExpression } = require('../evaluate');
+
+function near(actual, expected, eps = 1e-9) {
+  assert.ok(Math.abs(actual - expected) < eps, `expected ${expected} got ${actual}`);
+}
+
+near(evaluateExpression('2+2'), 4);
+near(evaluateExpression('5!'), 120);
+near(evaluateExpression('sqrt(9)'), 3);
+near(evaluateExpression('sin(30)', {isDegree: true}), 0.5);
+near(evaluateExpression('cos(0)'), 1);
+near(evaluateExpression('log(100)'), 2);
+near(evaluateExpression('ln(e)'), 1);
+near(evaluateExpression('2^3'), 8);
+near(evaluateExpression('50%'), 0.5);
+near(evaluateExpression('1+2*3'), 7);
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add expression parser implementation in `evaluate.js`
- replace inline evaluation with parser
- sanitize expressions and remove Function usage
- document secure evaluation in README
- add node tests for parser

## Testing
- `node test/evaluate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68690f504ef8832d9ae66e514924198d